### PR TITLE
Add simple authentication with roles

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,12 @@
 import os
 from datetime import datetime
-from flask import Flask, render_template, redirect, url_for, request, session
-from models import db, Task
+from functools import wraps
+
+from flask import Flask, render_template, redirect, url_for, request, session, abort
+from flask_login import LoginManager, login_user, logout_user, login_required, current_user
+from werkzeug.security import generate_password_hash, check_password_hash
+
+from models import db, Task, User
 import pandas as pd
 import plotly.figure_factory as ff
 import plotly.express as px
@@ -10,25 +15,73 @@ app = Flask(__name__)
 app.secret_key = 'dev'
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
+login_manager = LoginManager(app)
+login_manager.login_view = 'login'
+
+
+@login_manager.user_loader
+def load_user(user_id):
+    return User.query.get(int(user_id))
+
+
+def roles_required(*roles):
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            if not current_user.is_authenticated:
+                return login_manager.unauthorized()
+            if current_user.role not in roles:
+                abort(403)
+            return f(*args, **kwargs)
+        return decorated_function
+    return decorator
+
 
 def init_db(project_name):
     base = os.path.abspath(os.path.dirname(__file__))
     os.makedirs(os.path.join(base, 'data', 'projects'), exist_ok=True)
     db_path = os.path.join(base, 'data', 'projects', f'{project_name}.db')
+    master_path = os.path.join(base, 'data', 'master.db')
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
+    app.config['SQLALCHEMY_BINDS'] = {'users': f'sqlite:///{master_path}'}
     db.init_app(app)
     with app.app_context():
         db.create_all()
+        if not User.query.filter_by(username='admin').first():
+            admin = User(username='admin', password_hash=generate_password_hash('admin'), role='Admin')
+            db.session.add(admin)
+            db.session.commit()
 
 
 @app.before_request
 def load_project():
     project = session.get('project')
-    if not project and request.endpoint not in ('select_project', 'static'):
+    if not project and request.endpoint not in ('select_project', 'login', 'static'):
         return redirect(url_for('select_project'))
 
 
+@app.route('/login', methods=['GET', 'POST'])
+def login():
+    if request.method == 'POST':
+        username = request.form['username']
+        password = request.form['password']
+        user = User.query.filter_by(username=username).first()
+        if user and check_password_hash(user.password_hash, password):
+            login_user(user)
+            return redirect(url_for('tasks'))
+    return render_template('login.html')
+
+
+@app.route('/logout')
+@login_required
+def logout():
+    logout_user()
+    return redirect(url_for('login'))
+
+
 @app.route('/select', methods=['GET', 'POST'])
+@login_required
+@roles_required('Admin', 'User')
 def select_project():
     projects = [p[:-3] for p in os.listdir('data/projects') if p.endswith('.db')]
     if request.method == 'POST':
@@ -40,6 +93,7 @@ def select_project():
 
 
 @app.route('/')
+@login_required
 def tasks():
     project = session.get('project')
     if not project:
@@ -70,6 +124,8 @@ def tasks():
 
 
 @app.route('/task/add', methods=['GET', 'POST'])
+@login_required
+@roles_required('Admin', 'User')
 def add_task():
     if request.method == 'POST':
         name = request.form['name']
@@ -84,6 +140,8 @@ def add_task():
 
 
 @app.route('/task/<int:task_id>/edit', methods=['GET', 'POST'])
+@login_required
+@roles_required('Admin', 'User')
 def edit_task(task_id):
     task = Task.query.get_or_404(task_id)
     if request.method == 'POST':
@@ -97,6 +155,8 @@ def edit_task(task_id):
 
 
 @app.route('/task/<int:task_id>/delete', methods=['POST'])
+@login_required
+@roles_required('Admin', 'User')
 def delete_task(task_id):
     task = Task.query.get_or_404(task_id)
     db.session.delete(task)
@@ -105,6 +165,7 @@ def delete_task(task_id):
 
 
 @app.route('/dashboard')
+@login_required
 def dashboard():
     tasks = Task.query.order_by(Task.end_date).all()
     if not tasks:

--- a/models.py
+++ b/models.py
@@ -1,8 +1,17 @@
 from flask_sqlalchemy import SQLAlchemy
+from flask_login import UserMixin
 
+# database instance
+# 'db' is used for task databases (per project) and also binds to the user database
 
 db = SQLAlchemy()
 
+class User(UserMixin, db.Model):
+    __bind_key__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    username = db.Column(db.String(80), unique=True, nullable=False)
+    password_hash = db.Column(db.String(128), nullable=False)
+    role = db.Column(db.String(20), nullable=False, default='User')
 
 class Task(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask
 Flask_SQLAlchemy
+Flask_Login
 pandas
 plotly

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,8 +11,15 @@
     <div class="container-fluid">
         <a class="navbar-brand" href="{{ url_for('tasks') }}">ProjectTool</a>
         <div>
+            {% if current_user.is_authenticated and current_user.role in ['Admin', 'User'] %}
             <a class="nav-link d-inline" href="{{ url_for('add_task') }}">Add Task</a>
+            {% endif %}
             <a class="nav-link d-inline" href="{{ url_for('dashboard') }}">Dashboard</a>
+            {% if current_user.is_authenticated %}
+            <a class="nav-link d-inline" href="{{ url_for('logout') }}">Logout</a>
+            {% else %}
+            <a class="nav-link d-inline" href="{{ url_for('login') }}">Login</a>
+            {% endif %}
         </div>
     </div>
 </nav>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -19,10 +19,12 @@
             <td>{{ task.end_date }}</td>
             <td>{{ task.progress }}</td>
             <td>
+                {% if current_user.is_authenticated and current_user.role in ['Admin', 'User'] %}
                 <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-secondary">Edit</a>
                 <form action="{{ url_for('delete_task', task_id=task.id) }}" method="post" style="display:inline-block">
                     <button type="submit" class="btn btn-sm btn-danger">Delete</button>
                 </form>
+                {% endif %}
             </td>
         </tr>
     {% endfor %}


### PR DESCRIPTION
## Summary
- implement `User` model with hashed passwords and roles
- add Flask-Login based authentication
- restrict task actions to Admin/User roles
- update navigation to show login/logout links
- record Flask-Login in requirements

## Testing
- `python -m py_compile app.py models.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_687965b6279c8321be465416f70b6287