### PR TITLE
Enable project creation and selection via master DB

### DIFF
--- a/models.py
+++ b/models.py
@@ -19,3 +19,12 @@ class Task(db.Model):
     start_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date, nullable=False)
     progress = db.Column(db.Integer, default=0)
+
+
+class Project(db.Model):
+    """Project metadata stored in the master database."""
+
+    __bind_key__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), unique=True, nullable=False)
+    path = db.Column(db.String(255), nullable=False)

--- a/templates/project_create.html
+++ b/templates/project_create.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Create Project</h1>
+<form method="post">
+    <div class="mb-3">
+        <label class="form-label">Project Name</label>
+        <input type="text" name="name" class="form-control" required>
+    </div>
+    <button type="submit" class="btn btn-primary">Create</button>
+</form>
+{% endblock %}

--- a/templates/project_select.html
+++ b/templates/project_select.html
@@ -12,4 +12,5 @@
     </div>
     <button type="submit" class="btn btn-primary">Open</button>
 </form>
+<a href="{{ url_for('create_project') }}" class="btn btn-secondary mt-3">New Project</a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- add `Project` model stored in the master database
- update `init_db()` to register projects and initialise DB only once
- allow users to create new projects
- update project selection to read from the Projects table
- add templates for creating projects and new project link

## Testing
- `pytest -q`
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_6879673de4788321a3323e61cc190387