### PR TITLE
Add milestone handling to tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ All required assets such as Bootstrap and Plotly are bundled inside the `static/
 - Add, edit and delete tasks
 - Gantt and burndown charts with Plotly
 - Multiple project files selectable at start
+- Milestone tasks with zero duration
 
 ## Setup
 1. Install dependencies

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -23,7 +23,7 @@
             <td>{{ task.assigned_to or '' }}</td>
             <td>{{ task.progress }}</td>
             <td>{{ task.depends_on.name if task.depends_on else '' }}</td>
-            <td>{% if task.is_milestone %}&#9733;{% endif %}</td>
+            <td>{% if task.is_milestone %}&#9670;{% endif %}</td>
             <td>
                 {% if current_user.is_authenticated and current_user.role in ['Admin', 'User'] %}
                 <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-secondary">Edit</a>


### PR DESCRIPTION
## Summary
- support marking tasks as milestones by setting end date to start date
- highlight milestones on Gantt chart
- show diamond marker in tasks list
- document milestone feature

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68796c8a64c883219a5d71c9f590d39a