### PR TITLE
Add scale toggle for Gantt chart

### DIFF
--- a/app.py
+++ b/app.py
@@ -190,6 +190,7 @@ def tasks():
     project = session.get('project')
     if not project:
         return redirect(url_for('select_project'))
+    scale = request.args.get('scale', 'day')
     tasks = Task.query.all()
     df = pd.DataFrame([
         {
@@ -215,10 +216,16 @@ def tasks():
             color_discrete_map=color_map,
         )
         fig.update_yaxes(autorange="reversed")
+        if scale == 'month':
+            fig.update_xaxes(dtick="M1")
+        elif scale == 'week':
+            fig.update_xaxes(dtick="D7")
+        else:
+            fig.update_xaxes(dtick="D1")
         gantt = fig.to_html(full_html=False, include_plotlyjs=False)
     else:
         gantt = ''
-    return render_template('tasks.html', tasks=tasks, gantt=gantt)
+    return render_template('tasks.html', tasks=tasks, gantt=gantt, scale=scale)
 
 
 @app.route('/task/add', methods=['GET', 'POST'])

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,6 +1,14 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">Tasks</h1>
+<form method="get" id="scaleForm" class="mb-3">
+    <label for="scale" class="me-2">View:</label>
+    <select name="scale" id="scale" onchange="document.getElementById('scaleForm').submit()" class="form-select d-inline w-auto">
+        <option value="day" {% if scale == 'day' %}selected{% endif %}>Day</option>
+        <option value="week" {% if scale == 'week' %}selected{% endif %}>Week</option>
+        <option value="month" {% if scale == 'month' %}selected{% endif %}>Month</option>
+    </select>
+</form>
 <table class="table">
     <thead>
         <tr>


### PR DESCRIPTION
## Summary
- add scale selector dropdown on tasks page
- support scale query param in tasks route and adjust Plotly x-axis

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_68797388bc348321aec8e02e4773ea00