### PR TITLE
Enhance UX with modals, toasts and client validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os
 from datetime import datetime
 from functools import wraps
 
-from flask import Flask, render_template, redirect, url_for, request, session, abort
+from flask import Flask, render_template, redirect, url_for, request, session, abort, flash
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -155,6 +155,7 @@ def add_resource():
         r = Resource(name=name, role=role, color=color, utilization=utilization)
         db.session.add(r)
         db.session.commit()
+        flash('Resource added', 'success')
         return redirect(url_for('resources'))
     return render_template('resource_form.html', resource=None)
 
@@ -170,6 +171,7 @@ def edit_resource(resource_id):
         resource.color = request.form.get('color')
         resource.utilization = int(request.form.get('utilization') or 100)
         db.session.commit()
+        flash('Resource updated', 'success')
         return redirect(url_for('resources'))
     return render_template('resource_form.html', resource=resource)
 
@@ -181,6 +183,7 @@ def delete_resource(resource_id):
     resource = Resource.query.get_or_404(resource_id)
     db.session.delete(resource)
     db.session.commit()
+    flash('Resource deleted', 'success')
     return redirect(url_for('resources'))
 
 
@@ -254,6 +257,7 @@ def add_task():
         )
         db.session.add(task)
         db.session.commit()
+        flash('Task added', 'success')
         return redirect(url_for('tasks'))
     tasks = Task.query.all()
     resources = Resource.query.all()
@@ -277,6 +281,7 @@ def edit_task(task_id):
         if task.is_milestone:
             task.end_date = task.start_date
         db.session.commit()
+        flash('Task updated', 'success')
         return redirect(url_for('tasks'))
     tasks = Task.query.filter(Task.id != task_id).all()
     resources = Resource.query.all()
@@ -290,6 +295,7 @@ def delete_task(task_id):
     task = Task.query.get_or_404(task_id)
     db.session.delete(task)
     db.session.commit()
+    flash('Task deleted', 'success')
     return redirect(url_for('tasks'))
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,5 +1,15 @@
 console.log('App initialized');
 document.addEventListener('DOMContentLoaded', () => {
+  window.showToast = function(message, category = 'info') {
+    const container = document.getElementById('toastContainer');
+    if (!container) return;
+    const div = document.createElement('div');
+    div.className = `toast align-items-center text-bg-${category === 'success' ? 'success' : category === 'error' ? 'danger' : 'info'} border-0 mb-2`;
+    div.role = 'alert';
+    div.innerHTML = `<div class="d-flex"><div class="toast-body">${message}</div><button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button></div>`;
+    container.appendChild(div);
+    new bootstrap.Toast(div).show();
+  };
   const progress = document.getElementById('progress');
   const progressValue = document.getElementById('progressValue');
   if (progress && progressValue) {
@@ -55,10 +65,44 @@ document.addEventListener('DOMContentLoaded', () => {
           if (res.ok) {
             location.reload();
           } else {
-            alert('Save failed');
+            showToast('Save failed', 'error');
           }
         });
       });
     }
+  }
+
+  const deleteModal = document.getElementById('deleteTaskModal');
+  if (deleteModal) {
+    const deleteForm = document.getElementById('deleteTaskForm');
+    document.querySelectorAll('.delete-task-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        deleteForm.action = `/task/${btn.dataset.id}/delete`;
+        new bootstrap.Modal(deleteModal).show();
+      });
+    });
+  }
+
+  const taskForm = document.getElementById('taskForm');
+  if (taskForm) {
+    taskForm.addEventListener('submit', (e) => {
+      const start = new Date(taskForm.querySelector('input[name="start_date"]').value);
+      const end = new Date(taskForm.querySelector('input[name="end_date"]').value);
+      if (start > end) {
+        e.preventDefault();
+        showToast('Start date must be before end date', 'error');
+      }
+    });
+  }
+
+  const resourceForm = document.getElementById('resourceForm');
+  if (resourceForm) {
+    resourceForm.addEventListener('submit', (e) => {
+      const util = resourceForm.querySelector('input[name="utilization"]').value;
+      if (util && (util < 0 || util > 100)) {
+        e.preventDefault();
+        showToast('Utilization must be between 0 and 100', 'error');
+      }
+    });
   }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,9 +39,26 @@
 <div class="container">
     {% block content %}{% endblock %}
 </div>
+{% with messages = get_flashed_messages(with_categories=true) %}
+<div id="toastContainer" class="position-fixed bottom-0 end-0 p-3" style="z-index:11">
+  {% for category, message in messages %}
+  <div class="toast align-items-center text-bg-{{ 'success' if category=='success' else 'danger' if category=='error' else 'info' }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
+    <div class="d-flex">
+      <div class="toast-body">{{ message }}</div>
+      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+    </div>
+  </div>
+  {% endfor %}
+</div>
+{% endwith %}
 <script src="{{ url_for('static', filename='libs/bootstrap.bundle.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/plotly.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/app.js') }}"></script>
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('#toastContainer .toast').forEach(el => new bootstrap.Toast(el).show());
+});
+</script>
 </body>
 </html>

--- a/templates/form.html
+++ b/templates/form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">{{ 'Edit Task' if task else 'Add Task' }}</h1>
-<form method="post">
+<form method="post" id="taskForm">
     <div class="mb-3">
         <label class="form-label">Name</label>
         <input type="text" name="name" value="{{ task.name if task else '' }}" class="form-control" required>

--- a/templates/resource_form.html
+++ b/templates/resource_form.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">{{ 'Edit Resource' if resource else 'Add Resource' }}</h1>
-<form method="post">
+<form method="post" id="resourceForm">
     <div class="mb-3">
         <label class="form-label">Name</label>
         <input type="text" name="name" value="{{ resource.name if resource else '' }}" class="form-control" required>

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -54,11 +54,9 @@
                         data-is-milestone="{{ task.is_milestone }}">
                     <img src="{{ url_for('static', filename='icons/pencil.svg') }}" class="icon" alt="Edit">
                 </button>
-                <form action="{{ url_for('delete_task', task_id=task.id) }}" method="post" style="display:inline-block">
-                    <button type="submit" class="btn btn-sm btn-danger">
-                        <img src="{{ url_for('static', filename='icons/trash.svg') }}" class="icon" alt="Delete">
-                    </button>
-                </form>
+                <button type="button" class="btn btn-sm btn-danger delete-task-btn" data-id="{{ task.id }}">
+                    <img src="{{ url_for('static', filename='icons/trash.svg') }}" class="icon" alt="Delete">
+                </button>
                 {% endif %}
             </td>
         </tr>
@@ -121,6 +119,27 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
         <button type="button" class="btn btn-primary" id="saveTaskBtn">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Delete Task Modal -->
+<div class="modal fade" id="deleteTaskModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Confirm Delete</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to delete this task?
+      </div>
+      <div class="modal-footer">
+        <form id="deleteTaskForm" method="post">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="submit" class="btn btn-danger">Delete</button>
+        </form>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show Bootstrap toast messages for flash notifications
- confirm task deletion via new modal dialog
- validate forms in client-side JavaScript
- add success flashes for CRUD actions

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68797c8855ac8321b983c5175d869857