### PR TITLE
Implement member management and DB migration

### DIFF
--- a/models.py
+++ b/models.py
@@ -13,7 +13,8 @@ class User(UserMixin, db.Model):
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
     password_hash = db.Column(db.String(128), nullable=False)
-    role = db.Column(db.String(20), nullable=False, default='User')
+    # Default to Viewer permissions for regular users
+    role = db.Column(db.String(20), nullable=False, default='Viewer')
 
 class Resource(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -23,18 +24,41 @@ class Resource(db.Model):
     utilization = db.Column(db.Integer, default=100)
 
 
+class Member(db.Model):
+    """Project team member."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100), unique=True, nullable=False)
+
+
 class Task(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(100), nullable=False)
     start_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date, nullable=False)
     progress = db.Column(db.Integer, default=0)
+    remarks = db.Column(db.Text)
+    parent_id = db.Column(db.Integer, db.ForeignKey('task.id'))
+    parent = db.relationship('Task', remote_side=[id])
+    assignee_id = db.Column(db.Integer, db.ForeignKey('member.id'))
+    assignee = db.relationship('Member')
     resource_id = db.Column(db.Integer, db.ForeignKey('resource.id'))
     resource = db.relationship('Resource')
     depends_on_id = db.Column(db.Integer, db.ForeignKey('task.id'))
     depends_on = db.relationship('Task', remote_side=[id])
     is_milestone = db.Column(db.Boolean, default=False)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+class TaskDependency(db.Model):
+    """Many-to-many dependency between tasks."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    predecessor_id = db.Column(db.Integer, db.ForeignKey('task.id'), nullable=False)
+    successor_id = db.Column(db.Integer, db.ForeignKey('task.id'), nullable=False)
+    predecessor = db.relationship('Task', foreign_keys=[predecessor_id])
+    successor = db.relationship('Task', foreign_keys=[successor_id])
+    __table_args__ = (db.UniqueConstraint('predecessor_id', 'successor_id'),)
 
 
 class Project(db.Model):

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -35,7 +35,7 @@ document.addEventListener('DOMContentLoaded', () => {
         modal.querySelector('input[name="name"]').value = btn.dataset.name;
         modal.querySelector('input[name="start_date"]').value = btn.dataset.start;
         modal.querySelector('input[name="end_date"]').value = btn.dataset.end;
-        modal.querySelector('select[name="resource_id"]').value = btn.dataset.resourceId || '';
+        modal.querySelector('select[name="assignee_id"]').value = btn.dataset.assigneeId || '';
         modal.querySelector('select[name="depends_on_id"]').value = btn.dataset.dependsOnId || '';
         modal.querySelector('input[name="is_milestone"]').checked = btn.dataset.isMilestone === 'True';
         modalProgress.value = btn.dataset.progress;
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
             start_date: modal.querySelector('input[name="start_date"]').value,
             end_date: modal.querySelector('input[name="end_date"]').value,
             progress: modalProgress.value,
-            resource_id: modal.querySelector('select[name="resource_id"]').value || null,
+            assignee_id: modal.querySelector('select[name="assignee_id"]').value || null,
             depends_on_id: modal.querySelector('select[name="depends_on_id"]').value || null,
             is_milestone: modal.querySelector('input[name="is_milestone"]').checked
           })

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,9 +25,12 @@
                 <li class="nav-item">
                     <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
                 </li>
-                {% if current_user.is_authenticated and current_user.role in ['Admin', 'User'] %}
+                {% if current_user.is_authenticated and current_user.role in ['Admin', 'Editor'] %}
                 <li class="nav-item">
                     <a class="nav-link" href="{{ url_for('resources') }}">Resources</a>
+                </li>
+                <li class="nav-item">
+                    <a class="nav-link" href="{{ url_for('members') }}">Members</a>
                 </li>
                 {% endif %}
             </ul>

--- a/templates/form.html
+++ b/templates/form.html
@@ -16,10 +16,10 @@
     </div>
     <div class="mb-3">
         <label class="form-label">Assignee</label>
-        <select name="resource_id" class="form-select">
+        <select name="assignee_id" class="form-select">
             <option value="">-- None --</option>
-            {% for r in resources %}
-            <option value="{{ r.id }}" {% if task and task.resource_id == r.id %}selected{% endif %}>{{ r.name }}</option>
+            {% for m in members %}
+            <option value="{{ m.id }}" {% if task and task.assignee_id == m.id %}selected{% endif %}>{{ m.name }}</option>
             {% endfor %}
         </select>
     </div>

--- a/templates/member_form.html
+++ b/templates/member_form.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">{{ 'Edit Member' if member else 'Add Member' }}</h1>
+<form method="post" id="memberForm">
+    <div class="mb-3">
+        <label class="form-label">Name</label>
+        <input type="text" name="name" value="{{ member.name if member else '' }}" class="form-control" required>
+    </div>
+    
+    <button type="submit" class="btn btn-primary">Save</button>
+</form>
+{% endblock %}

--- a/templates/members.html
+++ b/templates/members.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block content %}
+<h1 class="mb-4">Members</h1>
+<a href="{{ url_for('add_member') }}" class="btn btn-primary mb-3">
+    <img src="{{ url_for('static', filename='icons/plus.svg') }}" class="icon me-1" alt=""> Add Member
+</a>
+<table class="table">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Actions</th>
+        </tr>
+    </thead>
+    <tbody>
+    {% for m in members %}
+        <tr>
+            <td>{{ m.name }}</td>
+            <td>
+                <a href="{{ url_for('edit_member', member_id=m.id) }}" class="btn btn-sm btn-secondary">
+                    <img src="{{ url_for('static', filename='icons/pencil.svg') }}" class="icon" alt="Edit">
+                </a>
+                <form action="{{ url_for('delete_member', member_id=m.id) }}" method="post" style="display:inline-block">
+                    <button type="submit" class="btn btn-sm btn-danger">
+                        <img src="{{ url_for('static', filename='icons/trash.svg') }}" class="icon" alt="Delete">
+                    </button>
+                </form>
+            </td>
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% endblock %}

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h1 class="mb-4">Tasks</h1>
-{% if current_user.is_authenticated and current_user.role in ['Admin', 'User'] %}
+{% if current_user.is_authenticated and current_user.role in ['Admin', 'Editor'] %}
 <a href="{{ url_for('add_task') }}" class="btn btn-primary mb-3">
     <img src="{{ url_for('static', filename='icons/plus.svg') }}" class="icon me-1" alt=""> Add Task
 </a>
@@ -33,7 +33,7 @@
             <td>{{ task.name }}</td>
             <td>{{ task.start_date }}</td>
             <td>{{ task.end_date }}</td>
-            <td>{{ task.resource.name if task.resource else '' }}</td>
+            <td>{{ task.assignee.name if task.assignee else '' }}</td>
             <td>
                 <div class="progress">
                     <div class="progress-bar" role="progressbar" style="width: {{ task.progress }}%;" aria-valuenow="{{ task.progress }}" aria-valuemin="0" aria-valuemax="100">{{ task.progress }}%</div>
@@ -42,13 +42,13 @@
             <td>{{ task.depends_on.name if task.depends_on else '' }}</td>
             <td>{% if task.is_milestone %}&#9670;{% endif %}</td>
             <td>
-                {% if current_user.is_authenticated and current_user.role in ['Admin', 'User'] %}
+                {% if current_user.is_authenticated and current_user.role in ['Admin', 'Editor'] %}
                 <button type="button" class="btn btn-sm btn-secondary edit-task-btn"
                         data-id="{{ task.id }}"
                         data-name="{{ task.name }}"
                         data-start="{{ task.start_date }}"
                         data-end="{{ task.end_date }}"
-                        data-resource-id="{{ task.resource_id }}"
+                        data-assignee-id="{{ task.assignee_id }}"
                         data-depends-on-id="{{ task.depends_on_id }}"
                         data-progress="{{ task.progress }}"
                         data-is-milestone="{{ task.is_milestone }}">
@@ -90,10 +90,10 @@
         </div>
         <div class="mb-3">
           <label class="form-label">Assignee</label>
-          <select name="resource_id" class="form-select">
+          <select name="assignee_id" class="form-select">
             <option value="">-- None --</option>
-            {% for r in resources %}
-            <option value="{{ r.id }}">{{ r.name }}</option>
+            {% for m in members %}
+            <option value="{{ m.id }}">{{ m.name }}</option>
             {% endfor %}
           </select>
         </div>


### PR DESCRIPTION
## Summary
- add `Member` and `TaskDependency` models
- expand `Task` schema with remarks, parent and assignee links
- default `User.role` to `Viewer`
- create pages and routes for managing members
- change task views to use members instead of resources
- update JS and DB migration logic

## Testing
- `python -m py_compile app.py models.py`

------
https://chatgpt.com/codex/tasks/task_e_687a0da5cc1883219a7e0395b6b9f6d2