### PR TITLE
Add Bootstrap-based base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,71 +1,60 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="ja">
 <head>
-    <meta charset="utf-8">
-    <title>Project Management Tool</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='libs/bootstrap.min.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/styles.css') }}">
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <meta charset="UTF-8">
+  <title>ProjectManagementTool</title>
+  <!-- Bootstrap CSS -->
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <!-- ナビゲーションバー -->
+  <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
     <div class="container-fluid">
-        <a class="navbar-brand" href="{{ url_for('tasks') }}">{{ session.get('project', 'ProjectTool') }}</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
-            <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-            <ul class="navbar-nav me-auto mb-2 mb-lg-0">
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('index') }}">Overview</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('tasks') }}">Tasks</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('dashboard') }}">Dashboard</a>
-                </li>
-                {% if current_user.is_authenticated and current_user.role in ['Admin', 'Editor'] %}
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('resources') }}">Resources</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link" href="{{ url_for('members') }}">Members</a>
-                </li>
-                {% endif %}
-            </ul>
-            {% if current_user.is_authenticated %}
-            <span class="navbar-text me-3">{{ current_user.username }}</span>
-            <a class="btn btn-outline-light btn-sm" href="{{ url_for('logout') }}">Logout</a>
-            {% else %}
-            <a class="btn btn-outline-light btn-sm" href="{{ url_for('login') }}">Login</a>
-            {% endif %}
-        </div>
+      <a class="navbar-brand" href="{{ url_for('dashboard') }}">📊 ProjectManagementTool</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainnav" aria-controls="mainnav" aria-expanded="false" aria-label="Toggle nav">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="mainnav">
+        <ul class="navbar-nav me-auto mb-2 mb-lg-0">
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">ダッシュボード</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('tasks') }}">タスク</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('members') }}">メンバー</a></li>
+          {% if current_user.is_authenticated %}
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('open_project') }}">🔁 プロジェクトを開く</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('new_project') }}">💾 新規プロジェクト</a></li>
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">ログアウト</a></li>
+          {% else %}
+            <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">ログイン</a></li>
+          {% endif %}
+        </ul>
+      </div>
     </div>
-</nav>
-<div class="container">
-    {% block content %}{% endblock %}
-</div>
-{% with messages = get_flashed_messages(with_categories=true) %}
-<div id="toastContainer" class="position-fixed bottom-0 end-0 p-3" style="z-index:11">
-  {% for category, message in messages %}
-  <div class="toast align-items-center text-bg-{{ 'success' if category=='success' else 'danger' if category=='error' else 'info' }} border-0 mb-2" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="d-flex">
-      <div class="toast-body">{{ message }}</div>
-      <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
-    </div>
+  </nav>
+  
+  <!-- フラッシュメッセージ表示 -->
+  <div class="container mt-2">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+        {% for category, msg in messages %}
+          <div class="alert alert-{{ 'danger' if category=='error' else category }} alert-dismissible fade show" role="alert">
+            {{ msg }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+          </div>
+        {% endfor %}
+      {% endif %}
+    {% endwith %}
   </div>
-  {% endfor %}
-</div>
-{% endwith %}
-<script src="{{ url_for('static', filename='libs/bootstrap.bundle.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/plotly.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/app.js') }}"></script>
-<script>
-document.addEventListener('DOMContentLoaded', () => {
-  document.querySelectorAll('#toastContainer .toast').forEach(el => new bootstrap.Toast(el).show());
-});
-</script>
+  
+  <!-- ページコンテンツ -->
+  <div class="container my-4">
+    {% block content %}{% endblock %}
+  </div>
+
+  <!-- Bootstrap Bundle JS -->
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="{{ url_for('static', filename='js/plotly.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/d3.min.js') }}"></script>
+  <script src="{{ url_for('static', filename='js/app.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh base.html with a Bootstrap 5 layout
- include navigation links to dashboard, tasks, members and project actions
- show flash messages as dismissible alerts

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_687a16ab7a7c832186839b9958eaca03