### PR TITLE
Add simplified Gantt chart and extended task list

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,3 +2,13 @@
 .gantt-container {
     overflow-x: auto;
 }
+.gantt-bar {
+    height: 1.2rem;
+    color: #fff;
+    padding: 0 4px;
+    font-size: 0.75rem;
+    white-space: nowrap;
+}
+.bar-complete { background-color: #28a745; }
+.bar-ongoing { background-color: #0d6efd; }
+.bar-delayed { background-color: #dc3545; }

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -1,147 +1,147 @@
-{% extends 'base.html' %}
+{% extends "base.html" %}
 {% block content %}
-<h1 class="mb-4">Tasks</h1>
-{% if current_user.is_authenticated and current_user.role in ['Admin', 'Editor'] %}
-<a href="{{ url_for('add_task') }}" class="btn btn-primary mb-3">
-    <img src="{{ url_for('static', filename='icons/plus.svg') }}" class="icon me-1" alt=""> Add Task
-</a>
+<h2>📋 タスク一覧</h2>
+
+<!-- タスク追加フォーム -->
+{% if current_user.role != 'Viewer' %}
+<div class="mb-4 p-3 border rounded bg-light">
+  <h5>新規タスク追加</h5>
+  <form method="POST" class="row g-3">
+    <div class="col-md-6">
+      <label class="form-label">タスク名</label>
+      <input type="text" name="name" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">開始日</label>
+      <input type="date" name="start_date" class="form-control" required>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">終了日</label>
+      <input type="date" name="end_date" class="form-control" required>
+    </div>
+    <div class="col-12">
+      <label class="form-label">備考</label>
+      <textarea name="remarks" class="form-control" rows="2"></textarea>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">担当者</label>
+      <select name="assignee_id" class="form-select">
+        <option value="">-- 未設定 --</option>
+        {% for m in members %}
+          <option value="{{ m.id }}">{{ m.name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">先行タスク (依存関係)</label>
+      <select name="predecessors" multiple class="form-select">
+        {% for t in tasks %}
+          <option value="{{ t.id }}">{{ t.name }}</option>
+        {% endfor %}
+      </select>
+      <small class="text-muted">※この新タスクが開始する前に完了すべきタスクを選択（複数可）</small>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">親タスク (フェーズ)</label>
+      <select name="parent_id" class="form-select">
+        <option value="">-- なし --</option>
+        {% for t in tasks if not t.parent_id %}
+          <option value="{{ t.id }}">{{ t.name }}</option>
+        {% endfor %}
+      </select>
+      <small class="text-muted">※このタスクを含むフェーズや親タスクがあれば選択</small>
+    </div>
+    <div class="col-md-4">
+      <label class="form-label">進捗率</label>
+      <div class="input-group">
+        <input type="number" name="progress" class="form-control" value="0" min="0" max="100">
+        <span class="input-group-text">%</span>
+      </div>
+    </div>
+    <div class="col-12">
+      <button type="submit" class="btn btn-primary">追加</button>
+    </div>
+  </form>
+</div>
 {% endif %}
-<form method="get" id="scaleForm" class="mb-3">
-    <label for="scale" class="me-2">View:</label>
-    <select name="scale" id="scale" onchange="document.getElementById('scaleForm').submit()" class="form-select d-inline w-auto">
-        <option value="day" {% if scale == 'day' %}selected{% endif %}>Day</option>
-        <option value="week" {% if scale == 'week' %}selected{% endif %}>Week</option>
-        <option value="month" {% if scale == 'month' %}selected{% endif %}>Month</option>
-    </select>
-</form>
-<table class="table">
-    <thead>
-        <tr>
-            <th>Name</th>
-            <th>Start</th>
-            <th>End</th>
-            <th>Assignee</th>
-            <th>Progress (%)</th>
-            <th>Depends On</th>
-            <th>Milestone</th>
-            <th>Actions</th>
-        </tr>
-    </thead>
-    <tbody>
-    {% for task in tasks %}
-        <tr>
-            <td>{{ task.name }}</td>
-            <td>{{ task.start_date }}</td>
-            <td>{{ task.end_date }}</td>
-            <td>{{ task.assignee.name if task.assignee else '' }}</td>
-            <td>
-                <div class="progress">
-                    <div class="progress-bar" role="progressbar" style="width: {{ task.progress }}%;" aria-valuenow="{{ task.progress }}" aria-valuemin="0" aria-valuemax="100">{{ task.progress }}%</div>
-                </div>
-            </td>
-            <td>{{ task.depends_on.name if task.depends_on else '' }}</td>
-            <td>{% if task.is_milestone %}&#9670;{% endif %}</td>
-            <td>
-                {% if current_user.is_authenticated and current_user.role in ['Admin', 'Editor'] %}
-                <button type="button" class="btn btn-sm btn-secondary edit-task-btn"
-                        data-id="{{ task.id }}"
-                        data-name="{{ task.name }}"
-                        data-start="{{ task.start_date }}"
-                        data-end="{{ task.end_date }}"
-                        data-assignee-id="{{ task.assignee_id }}"
-                        data-depends-on-id="{{ task.depends_on_id }}"
-                        data-progress="{{ task.progress }}"
-                        data-is-milestone="{{ task.is_milestone }}">
-                    <img src="{{ url_for('static', filename='icons/pencil.svg') }}" class="icon" alt="Edit">
-                </button>
-                <button type="button" class="btn btn-sm btn-danger delete-task-btn" data-id="{{ task.id }}">
-                    <img src="{{ url_for('static', filename='icons/trash.svg') }}" class="icon" alt="Delete">
-                </button>
-                {% endif %}
-            </td>
-        </tr>
+
+<!-- タスク一覧テーブル -->
+<table class="table table-sm table-hover align-middle">
+  <thead class="table-light">
+    <tr>
+      <th>No</th><th>タスク名</th><th>開始日</th><th>終了日</th>
+      <th>担当者</th><th>進捗</th><th>先行タスク</th><th>備考</th><th>操作</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for t in tasks %}
+    <tr class="{% if t.progress == 100 %}table-success{% elif t.end_date < current_date and t.progress < 100 %}table-danger{% endif %}">
+      <td>{{ loop.index }}</td>
+      <td>
+        {% if t.parent_id %} &emsp; 🔹 {% endif %}
+        {{ t.name }}
+      </td>
+      <td>{{ t.start_date }}</td>
+      <td>{{ t.end_date }}</td>
+      <td>{{ t.assignee.name if t.assignee else '' }}</td>
+      <td>{{ t.progress }}%</td>
+      <td>
+        {% set preds = [] %}
+        {% for dep in deps if dep.successor_id == t.id %}
+          {% set _ = preds.append(dep.predecessor.name) %}
+        {% endfor %}
+        {{ preds|join(', ') }}
+      </td>
+      <td>{{ t.remarks }}</td>
+      <td>
+        {% if current_user.role != 'Viewer' %}
+          <a href="{{ url_for('edit_task', task_id=t.id) }}" class="btn btn-sm btn-secondary">編集</a>
+          <form action="{{ url_for('delete_task', task_id=t.id) }}" method="POST" class="d-inline">
+            <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('削除しますか?');">削除</button>
+          </form>
+        {% else %}
+          <small class="text-muted">閲覧のみ</small>
+        {% endif %}
+      </td>
+    </tr>
     {% endfor %}
-    </tbody>
+  </tbody>
 </table>
-<div class="gantt-container">
-{{ gantt|safe }}
-</div>
 
-<!-- Edit Task Modal -->
-<div class="modal fade" id="editTaskModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Edit Task</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <div class="mb-3">
-          <label class="form-label">Name</label>
-          <input type="text" name="name" class="form-control" required>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Start Date</label>
-          <input type="date" name="start_date" class="form-control" required>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">End Date</label>
-          <input type="date" name="end_date" class="form-control" required>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Assignee</label>
-          <select name="assignee_id" class="form-select">
-            <option value="">-- None --</option>
-            {% for m in members %}
-            <option value="{{ m.id }}">{{ m.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Depends On</label>
-          <select name="depends_on_id" class="form-select">
-            <option value="">-- None --</option>
-            {% for t in tasks %}
-            <option value="{{ t.id }}">{{ t.name }}</option>
-            {% endfor %}
-          </select>
-        </div>
-        <div class="form-check mb-3">
-          <input type="checkbox" name="is_milestone" class="form-check-input" id="modalMilestone">
-          <label for="modalMilestone" class="form-check-label">Milestone</label>
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Progress (%)</label>
-          <input type="range" name="progress" id="modalProgress" class="form-range" min="0" max="100" oninput="modalProgressValue.value = modalProgress.value">
-          <output id="modalProgressValue">0</output>%
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary" id="saveTaskBtn">Save</button>
-      </div>
+<!-- ガントチャート表示 -->
+<h3 class="mt-5">ガントチャート</h3>
+<div class="gantt-chart-container" style="overflow-x: auto; position: relative; padding: 1rem; border: 1px solid #ccc;">
+  <!-- 横軸（期間） -->
+  {% set project_start = tasks|map(attribute='start_date')|min %}
+  {% set project_end = tasks|map(attribute='end_date')|max %}
+  {% for d in range((project_end - project_start).days + 1) %}
+    {% set day_label = project_start + d*day %}
+    <div class="gantt-day-label" style="display:inline-block; width:20px;">
+      {{ day_label.day }}{% if day_label.day == 1 %}月{% endif %}
     </div>
-  </div>
-</div>
-
-<!-- Delete Task Modal -->
-<div class="modal fade" id="deleteTaskModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">Confirm Delete</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+  {% endfor %}
+  <div class="position-relative" style="margin-top: 1.5rem;">
+    {% for t in tasks %}
+      {% set offset = (t.start_date - project_start).days * 20 %}
+      {% set duration = (t.end_date - t.start_date).days * 20 + 20 %}
+      {% set status_class = 'bar-complete' if t.progress == 100 else 'bar-delayed' if (t.end_date < current_date and t.progress < 100) else 'bar-ongoing' %}
+      <div class="gantt-bar {{ status_class }}" 
+           style="position: absolute; left: {{ offset }}px; width: {{ duration }}px;"
+           title="{{ t.name }}: {{ t.progress }}%完了（{{ t.start_date }} - {{ t.end_date }}{% if t.assignee %}, 担当: {{ t.assignee.name }}{% endif %}）">
+        {{ t.name }}
       </div>
-      <div class="modal-body">
-        Are you sure you want to delete this task?
-      </div>
-      <div class="modal-footer">
-        <form id="deleteTaskForm" method="post">
-          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
-          <button type="submit" class="btn btn-danger">Delete</button>
-        </form>
-      </div>
-    </div>
+      {% for dep in deps if dep.predecessor_id == t.id %}
+        {% set succ_task = tasks|selectattr('id', 'equalto', dep.successor_id)|first %}
+        {% if succ_task %}
+          <div class="gantt-dependency-line" 
+               style="position: absolute; left: {{ (t.end_date - project_start).days * 20 + 20 }}px; top: {{ loop.index0 * 1.5 }}rem; width: {{ ((succ_task.start_date - t.end_date).days) * 20 - 4 }}px; border-bottom: 2px solid #000;">
+          </div>
+          <div class="gantt-dependency-arrow" 
+               style="position: absolute; left: {{ (succ_task.start_date - project_start).days * 20 }}px; top: {{ loop.index0 * 1.5 }}rem; width: 0; height: 0; border-top: 5px solid transparent; border-bottom: 5px solid transparent; border-left: 5px solid #000;">
+          </div>
+        {% endif %}
+      {% endfor %}
+    {% endfor %}
   </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- simplify task route and remove plotly
- add progress-based colors and dependency display to tasks table
- implement basic HTML/CSS Gantt chart with dependency lines

## Testing
- `python -m py_compile app.py`
- `python -m py_compile models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a1d6ec6608321b505d758487a4e56