### PR TITLE
Fix startup error with SQLAlchemy 3

### DIFF
--- a/models.py
+++ b/models.py
@@ -48,7 +48,8 @@ class Task(db.Model):
     assignee_id = db.Column(db.Integer, db.ForeignKey('members.id'), nullable=True)
     # relationships
     children = db.relationship(
-        'Task', backref=db.backref('parent', remote_side=[id])
+        'Task', backref=db.backref('parent', remote_side=[id]),
+        foreign_keys=[parent_id]
     )
     assignee = db.relationship(
         'Member', backref=db.backref('tasks', lazy='dynamic')
@@ -56,7 +57,8 @@ class Task(db.Model):
     resource_id = db.Column(db.Integer, db.ForeignKey('resource.id'))
     resource = db.relationship('Resource')
     depends_on_id = db.Column(db.Integer, db.ForeignKey('tasks.id'))
-    depends_on = db.relationship('Task', remote_side=[id])
+    depends_on = db.relationship('Task', remote_side=[id],
+                                foreign_keys=[depends_on_id])
     is_milestone = db.Column(db.Boolean, default=False)
     updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
 


### PR DESCRIPTION
## Summary
- adapt to new `db.get_engine` signature for Flask-SQLAlchemy 3
- use SQLAlchemy 2.0 connection API when executing raw SQL
- specify `foreign_keys` on self-referential `Task` relations to avoid ambiguity

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687a2886bf3c83218086f4bd08fc5a86