### PR TITLE
Fix POST on root tasks route

### DIFF
--- a/app.py
+++ b/app.py
@@ -316,7 +316,7 @@ def index():
 
 
 @app.route('/tasks', methods=['GET', 'POST'])
-@app.route('/')
+@app.route('/', methods=['GET', 'POST'])
 @login_required
 def tasks():
     project = session.get('project')


### PR DESCRIPTION
## Summary
- allow POST requests on the root path so task addition works

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687d860a2e3c832193c9ef6ffd24012f