### PR TITLE
Add release version filtering and new Gantt page

### DIFF
--- a/app.py
+++ b/app.py
@@ -90,6 +90,9 @@ def init_db(project_name, db_path=None):
         if 'assignee_id' not in cols:
             with engine.begin() as conn:
                 conn.execute(text('ALTER TABLE tasks ADD COLUMN assignee_id INTEGER'))
+        if 'release_version' not in cols:
+            with engine.begin() as conn:
+                conn.execute(text("ALTER TABLE tasks ADD COLUMN release_version VARCHAR"))
 
         user_engine = db.get_engine(bind_key='users')
         with user_engine.connect() as conn:
@@ -333,11 +336,13 @@ def tasks():
             flash('End date cannot be before start date.', 'danger')
             return redirect(url_for('tasks'))
         remarks = request.form.get('remarks', '')
+        release_version = request.form.get('release_version')
         assignee_id = request.form.get('assignee_id', type=int)
         progress = int(request.form.get('progress', 0))
         parent_id = request.form.get('parent_id', type=int)
         task = Task(name=name, start_date=start, end_date=end,
-                    remarks=remarks, progress=progress,
+                    remarks=remarks, release_version=release_version,
+                    progress=progress,
                     assignee_id=assignee_id, parent_id=parent_id)
         db.session.add(task)
         db.session.commit()
@@ -380,6 +385,7 @@ def add_task():
             flash('End date cannot be before start date.', 'danger')
             return redirect(url_for('add_task'))
         progress = int(request.form.get('progress') or 0)
+        release_version = request.form.get('release_version')
         assignee_id = request.form.get('assignee_id') or None
         depends_on_id = request.form.get('depends_on_id') or None
         is_milestone = 'is_milestone' in request.form
@@ -389,6 +395,7 @@ def add_task():
             name=name,
             start_date=start_date,
             end_date=end_date,
+            release_version=release_version,
             progress=progress,
             assignee_id=assignee_id,
             depends_on_id=depends_on_id,
@@ -414,6 +421,7 @@ def edit_task(task_id):
         task.start_date = datetime.strptime(request.form['start_date'], '%Y-%m-%d').date()
         task.end_date = datetime.strptime(request.form['end_date'], '%Y-%m-%d').date()
         task.remarks = request.form.get('remarks', '')
+        task.release_version = request.form.get('release_version')
         task.progress = int(request.form.get('progress', task.progress))
         task.assignee_id = request.form.get('assignee_id', type=int)
         task.parent_id = request.form.get('parent_id', type=int)
@@ -463,6 +471,7 @@ def update_task():
     task.start_date = datetime.strptime(data.get('start_date'), '%Y-%m-%d').date()
     task.end_date = datetime.strptime(data.get('end_date'), '%Y-%m-%d').date()
     task.remarks = data.get('remarks', task.remarks)
+    task.release_version = data.get('release_version', task.release_version)
     task.progress = int(data.get('progress', task.progress))
     task.assignee_id = data.get('assignee_id') or None
     task.parent_id = data.get('parent_id') or None
@@ -484,7 +493,12 @@ def update_task():
 @app.route('/dashboard')
 @login_required
 def dashboard():
-    tasks = Task.query.all()
+    release = request.args.get('release')
+    query = Task.query
+    if release:
+        query = query.filter(Task.release_version == release)
+    tasks = query.all()
+    releases = [r[0] for r in db.session.query(Task.release_version).distinct().all() if r[0]]
     total_tasks = len(tasks)
     completed_tasks = sum(1 for t in tasks if t.progress == 100)
     overdue_tasks = sum(1 for t in tasks if t.progress < 100 and t.end_date < date.today())
@@ -505,8 +519,52 @@ def dashboard():
         "completed_tasks": completed_tasks,
         "overdue_tasks": overdue_tasks,
         "progress_rate": progress_rate,
-        "remaining_by_date": remaining_by_date
+        "remaining_by_date": remaining_by_date,
+        "releases": releases,
+        "selected_release": release
     })
+
+
+@app.route('/gantt')
+@login_required
+def gantt_chart():
+    release = request.args.get('release')
+    query = Task.query
+    if release:
+        query = query.filter(Task.release_version == release)
+    tasks = query.all()
+    releases = [r[0] for r in db.session.query(Task.release_version).distinct().all() if r[0]]
+    if tasks:
+        import pandas as pd
+        import plotly.express as px
+        df = pd.DataFrame([
+            {
+                "Task": t.name,
+                "Start": t.start_date,
+                "Finish": t.end_date,
+                "Progress": t.progress,
+            }
+            for t in tasks
+        ])
+        fig = px.timeline(
+            df,
+            x_start="Start",
+            x_end="Finish",
+            y="Task",
+            color="Progress",
+            color_continuous_scale=["#dc3545", "#ffc107", "#28a745"],
+            range_color=[0, 100],
+        )
+        fig.update_yaxes(autorange="reversed")
+        gantt = fig.to_html(full_html=False, include_plotlyjs=False)
+    else:
+        gantt = None
+    return render_template(
+        "gantt.html",
+        gantt=gantt,
+        releases=releases,
+        selected_release=release,
+    )
 
 
 if __name__ == '__main__':

--- a/models.py
+++ b/models.py
@@ -43,6 +43,7 @@ class Task(db.Model):
     start_date = db.Column(db.Date, nullable=False)
     end_date = db.Column(db.Date, nullable=False)
     remarks = db.Column(db.Text, nullable=True)
+    release_version = db.Column(db.String(100))
     progress = db.Column(db.Integer, nullable=False, default=0)
     parent_id = db.Column(db.Integer, db.ForeignKey('tasks.id'), nullable=True)
     assignee_id = db.Column(db.Integer, db.ForeignKey('members.id'), nullable=True)

--- a/templates/base.html
+++ b/templates/base.html
@@ -19,6 +19,7 @@
         <ul class="navbar-nav me-auto mb-2 mb-lg-0">
           <li class="nav-item"><a class="nav-link" href="{{ url_for('dashboard') }}">ダッシュボード</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('tasks') }}">タスク</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('gantt_chart') }}">ガントチャート</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('members') }}">メンバー</a></li>
           {% if current_user.is_authenticated %}
             <li class="nav-item"><a class="nav-link" href="{{ url_for('open_project') }}">🔁 プロジェクトを開く</a></li>

--- a/templates/form.html
+++ b/templates/form.html
@@ -15,6 +15,10 @@
         <input type="date" name="end_date" value="{{ task.end_date if task else '' }}" class="form-control" required>
     </div>
     <div class="mb-3">
+        <label class="form-label">Release Version</label>
+        <input type="text" name="release_version" value="{{ task.release_version if task else '' }}" class="form-control">
+    </div>
+    <div class="mb-3">
         <label class="form-label">Assignee</label>
         <select name="assignee_id" class="form-select">
             <option value="">-- None --</option>

--- a/templates/gantt.html
+++ b/templates/gantt.html
@@ -1,0 +1,22 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>📈 ガントチャート</h2>
+<form method="get" class="mb-3">
+  <div class="input-group" style="max-width:300px;">
+    <select name="release" class="form-select" onchange="this.form.submit()">
+      <option value="">全てのリリース</option>
+      {% for r in releases %}
+      <option value="{{ r }}" {% if selected_release == r %}selected{% endif %}>{{ r }}</option>
+      {% endfor %}
+    </select>
+    {% if selected_release %}
+      <a href="{{ url_for('gantt_chart') }}" class="btn btn-secondary">解除</a>
+    {% endif %}
+  </div>
+</form>
+{% if gantt %}
+  {{ gantt|safe }}
+{% else %}
+  <p class="text-muted">表示するタスクがありません。</p>
+{% endif %}
+{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,6 +1,19 @@
 {% extends "base.html" %}
 {% block content %}
 <h2>📊 ダッシュボード: プロジェクト概要</h2>
+<form method="get" class="mb-3">
+  <div class="input-group" style="max-width:300px;">
+    <select name="release" class="form-select" onchange="this.form.submit()">
+      <option value="">全てのリリース</option>
+      {% for r in releases %}
+      <option value="{{ r }}" {% if selected_release == r %}selected{% endif %}>{{ r }}</option>
+      {% endfor %}
+    </select>
+    {% if selected_release %}
+      <a href="{{ url_for('dashboard') }}" class="btn btn-secondary">解除</a>
+    {% endif %}
+  </div>
+</form>
 <div class="row text-center my-4">
   <div class="col-md-3">
     <div class="card border-primary mb-3">

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -19,6 +19,10 @@
       <label class="form-label">終了日</label>
       <input type="date" name="end_date" class="form-control" required>
     </div>
+    <div class="col-md-3">
+      <label class="form-label">リリースバージョン</label>
+      <input type="text" name="release_version" class="form-control">
+    </div>
     <div class="col-12">
       <label class="form-label">備考</label>
       <textarea name="remarks" class="form-control" rows="2"></textarea>
@@ -69,7 +73,7 @@
 <table class="table table-sm table-hover align-middle">
   <thead class="table-light">
     <tr>
-      <th>No</th><th>タスク名</th><th>開始日</th><th>終了日</th>
+      <th>No</th><th>タスク名</th><th>開始日</th><th>終了日</th><th>リリース</th>
       <th>担当者</th><th>進捗</th><th>先行タスク</th><th>備考</th><th>操作</th>
     </tr>
   </thead>
@@ -83,6 +87,7 @@
       </td>
       <td>{{ t.start_date }}</td>
       <td>{{ t.end_date }}</td>
+      <td>{{ t.release_version or '' }}</td>
       <td>{{ t.assignee.name if t.assignee else '' }}</td>
       <td>{{ t.progress }}%</td>
       <td>


### PR DESCRIPTION
## Summary
- introduce `release_version` to tasks
- filter dashboard and Gantt view by release version
- add Plotly-based Gantt chart page
- show release version in task forms and table
- add navigation link to Gantt chart

## Testing
- `python -m py_compile app.py models.py`
- `python app.py` *(launched and terminated)*

------
https://chatgpt.com/codex/tasks/task_e_687d889114e083219ab1d95968bb451b