### PR TITLE
Improve tasks page with filters and collapse

### DIFF
--- a/app.py
+++ b/app.py
@@ -358,8 +358,26 @@ def tasks():
         flash(f"New task '{name}' added.", 'success')
         return redirect(url_for('tasks'))
 
-    tasks = Task.query.order_by(Task.start_date).all()
+    release = request.args.get('release')
+    assignee = request.args.get('assignee', type=int)
+    sort_by = request.args.get('sort', 'start_date')
+
+    query = Task.query
+    if release:
+        query = query.filter(Task.release_version == release)
+    if assignee:
+        query = query.filter(Task.assignee_id == assignee)
+
+    if sort_by == 'release':
+        query = query.order_by(Task.release_version, Task.start_date)
+    elif sort_by == 'assignee':
+        query = query.join(Member).order_by(Member.name, Task.start_date)
+    else:
+        query = query.order_by(Task.start_date)
+
+    tasks = query.all()
     members = Member.query.all()
+    releases = [r[0] for r in db.session.query(Task.release_version).distinct().all() if r[0]]
     deps = TaskDependency.query.all()
     current_date = date.today()
     day = timedelta(days=1)
@@ -367,6 +385,10 @@ def tasks():
         'tasks.html',
         tasks=tasks,
         members=members,
+        releases=releases,
+        selected_release=release,
+        selected_assignee=assignee,
+        sort_by=sort_by,
         deps=deps,
         current_date=current_date,
         day=day,

--- a/templates/tasks.html
+++ b/templates/tasks.html
@@ -2,82 +2,45 @@
 {% block content %}
 <h2>📋 タスク一覧</h2>
 
-<!-- タスク追加フォーム -->
-{% if current_user.role != 'Viewer' %}
-<div class="mb-4 p-3 border rounded bg-light">
-  <h5>新規タスク追加</h5>
-  <form method="POST" action="{{ url_for('tasks') }}" class="row g-3">
-    <div class="col-md-6">
-      <label class="form-label">タスク名</label>
-      <input type="text" name="name" class="form-control" required>
-    </div>
-    <div class="col-md-3">
-      <label class="form-label">開始日</label>
-      <input type="date" name="start_date" class="form-control" required>
-    </div>
-    <div class="col-md-3">
-      <label class="form-label">終了日</label>
-      <input type="date" name="end_date" class="form-control" required>
-    </div>
-    <div class="col-md-3">
-      <label class="form-label">リリースバージョン</label>
-      <input type="text" name="release_version" class="form-control">
-    </div>
-    <div class="col-12">
-      <label class="form-label">備考</label>
-      <textarea name="remarks" class="form-control" rows="2"></textarea>
-    </div>
-    <div class="col-md-4">
-      <label class="form-label">担当者</label>
-      <select name="assignee_id" class="form-select">
-        <option value="">-- 未設定 --</option>
-        {% for m in members %}
-          <option value="{{ m.id }}">{{ m.name }}</option>
-        {% endfor %}
-      </select>
-    </div>
-    <div class="col-md-4">
-      <label class="form-label">先行タスク (依存関係)</label>
-      <select name="predecessors" multiple class="form-select">
-        {% for t in tasks %}
-          <option value="{{ t.id }}">{{ t.name }}</option>
-        {% endfor %}
-      </select>
-      <small class="text-muted">※この新タスクが開始する前に完了すべきタスクを選択（複数可）</small>
-    </div>
-    <div class="col-md-4">
-      <label class="form-label">親タスク (フェーズ)</label>
-      <select name="parent_id" class="form-select">
-        <option value="">-- なし --</option>
-        {% for t in tasks if not t.parent_id %}
-          <option value="{{ t.id }}">{{ t.name }}</option>
-        {% endfor %}
-      </select>
-      <small class="text-muted">※このタスクを含むフェーズや親タスクがあれば選択</small>
-    </div>
-    <div class="col-md-4">
-      <label class="form-label">進捗率</label>
-      <div class="input-group">
-        <input type="number" name="progress" class="form-control" value="0" min="0" max="100">
-        <span class="input-group-text">%</span>
-      </div>
-    </div>
-    <div class="col-12">
-      <button type="submit" class="btn btn-primary">追加</button>
-    </div>
-  </form>
-</div>
-{% endif %}
+<!-- フィルター・ソート -->
+<form method="get" class="row g-2 mb-3">
+  <div class="col-auto">
+    <select name="release" class="form-select" onchange="this.form.submit()">
+      <option value="">全リリース</option>
+      {% for r in releases %}
+      <option value="{{ r }}" {% if selected_release == r %}selected{% endif %}>{{ r }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-auto">
+    <select name="assignee" class="form-select" onchange="this.form.submit()">
+      <option value="">全担当者</option>
+      {% for m in members %}
+      <option value="{{ m.id }}" {% if selected_assignee == m.id %}selected{% endif %}>{{ m.name }}</option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="col-auto">
+    <select name="sort" class="form-select" onchange="this.form.submit()">
+      <option value="start_date" {% if sort_by == 'start_date' %}selected{% endif %}>開始日順</option>
+      <option value="release" {% if sort_by == 'release' %}selected{% endif %}>リリース順</option>
+      <option value="assignee" {% if sort_by == 'assignee' %}selected{% endif %}>担当者順</option>
+    </select>
+  </div>
+</form>
 
-<!-- タスク一覧テーブル -->
-<table class="table table-sm table-hover align-middle">
-  <thead class="table-light">
-    <tr>
-      <th>No</th><th>タスク名</th><th>開始日</th><th>終了日</th><th>リリース</th>
-      <th>担当者</th><th>進捗</th><th>先行タスク</th><th>備考</th><th>操作</th>
-    </tr>
-  </thead>
-  <tbody>
+<div class="row">
+  <div class="col-lg-8">
+
+    <!-- タスク一覧テーブル -->
+    <table class="table table-sm table-hover align-middle">
+      <thead class="table-light">
+        <tr>
+          <th>No</th><th>タスク名</th><th>開始日</th><th>終了日</th><th>リリース</th>
+          <th>担当者</th><th>進捗</th><th>先行タスク</th><th>備考</th><th>操作</th>
+        </tr>
+      </thead>
+      <tbody>
     {% for t in tasks %}
     <tr class="{% if t.progress == 100 %}table-success{% elif t.end_date < current_date and t.progress < 100 %}table-danger{% endif %}">
       <td>{{ loop.index }}</td>
@@ -153,4 +116,76 @@
 {% else %}
   <p class="text-muted">タスクがありません。</p>
 {% endif %}
+  </div>
+
+  <div class="col-lg-4">
+    {% if current_user.role != 'Viewer' %}
+    <button class="btn btn-secondary mb-3" type="button" data-bs-toggle="collapse" data-bs-target="#newTaskForm" aria-expanded="true" aria-controls="newTaskForm">新規タスク追加フォーム</button>
+    <div id="newTaskForm" class="collapse show">
+      <div class="p-3 border rounded bg-light">
+        <form method="POST" action="{{ url_for('tasks') }}" class="row g-3">
+          <div class="col-md-6">
+            <label class="form-label">タスク名</label>
+            <input type="text" name="name" class="form-control" required>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">開始日</label>
+            <input type="date" name="start_date" class="form-control" required>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">終了日</label>
+            <input type="date" name="end_date" class="form-control" required>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">リリースバージョン</label>
+            <input type="text" name="release_version" class="form-control">
+          </div>
+          <div class="col-12">
+            <label class="form-label">備考</label>
+            <textarea name="remarks" class="form-control" rows="2"></textarea>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">担当者</label>
+            <select name="assignee_id" class="form-select">
+              <option value="">-- 未設定 --</option>
+              {% for m in members %}
+              <option value="{{ m.id }}">{{ m.name }}</option>
+              {% endfor %}
+            </select>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">先行タスク (依存関係)</label>
+            <select name="predecessors" multiple class="form-select">
+              {% for t in tasks %}
+              <option value="{{ t.id }}">{{ t.name }}</option>
+              {% endfor %}
+            </select>
+            <small class="text-muted">※この新タスクが開始する前に完了すべきタスクを選択（複数可）</small>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">親タスク (フェーズ)</label>
+            <select name="parent_id" class="form-select">
+              <option value="">-- なし --</option>
+              {% for t in tasks if not t.parent_id %}
+              <option value="{{ t.id }}">{{ t.name }}</option>
+              {% endfor %}
+            </select>
+            <small class="text-muted">※このタスクを含むフェーズや親タスクがあれば選択</small>
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">進捗率</label>
+            <div class="input-group">
+              <input type="number" name="progress" class="form-control" value="0" min="0" max="100">
+              <span class="input-group-text">%</span>
+            </div>
+          </div>
+          <div class="col-12">
+            <button type="submit" class="btn btn-primary">追加</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    {% endif %}
+  </div>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refactor tasks route to support filtering by release and assignee
- add sorting options (start date, release, assignee)
- restructure tasks page layout: task list on the left and collapsible new-task form on the right
- provide dropdown filters and sorting UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app.py` *(fails: ModuleNotFoundError before install; works after install)*

------
https://chatgpt.com/codex/tasks/task_e_687da22c9cc08321bff86f1e7c54bafd