### PR TITLE
Implement REST API and improved gantt

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,0 +1,77 @@
+from flask import Blueprint, request, jsonify
+from flask_restful import Api, Resource
+from datetime import datetime
+from models import db, Task
+
+api_bp = Blueprint('api', __name__)
+api = Api(api_bp)
+
+class TaskResource(Resource):
+    def get(self, id):
+        task = Task.query.get_or_404(id)
+        return {
+            'id': task.id,
+            'name': task.name,
+            'start_date': task.start_date.isoformat(),
+            'end_date': task.end_date.isoformat(),
+            'remarks': task.remarks,
+            'release_version': task.release_version,
+            'progress': task.progress,
+            'assignee_id': task.assignee_id,
+            'parent_id': task.parent_id,
+        }
+
+class UpdateTask(Resource):
+    def post(self):
+        data = request.get_json() or {}
+        task = Task.query.get_or_404(data.get('id'))
+        if 'name' in data:
+            task.name = data['name']
+        if 'start_date' in data:
+            task.start_date = datetime.strptime(data['start_date'], '%Y-%m-%d').date()
+        if 'end_date' in data:
+            task.end_date = datetime.strptime(data['end_date'], '%Y-%m-%d').date()
+        if 'remarks' in data:
+            task.remarks = data['remarks']
+        if 'release_version' in data:
+            task.release_version = data['release_version']
+        if 'progress' in data:
+            task.progress = int(data['progress'])
+        if 'assignee_id' in data:
+            task.assignee_id = data['assignee_id']
+        if 'parent_id' in data:
+            task.parent_id = data['parent_id']
+        db.session.commit()
+        return {'status': 'ok'}
+
+class UpdateDates(Resource):
+    def post(self):
+        data = request.get_json() or {}
+        task = Task.query.get_or_404(data.get('id'))
+        if 'start_date' in data:
+            task.start_date = datetime.strptime(data['start_date'], '%Y-%m-%d').date()
+        if 'end_date' in data:
+            task.end_date = datetime.strptime(data['end_date'], '%Y-%m-%d').date()
+        db.session.commit()
+        return {'status': 'ok'}
+
+class BulkEdit(Resource):
+    def post(self):
+        data = request.get_json() or {}
+        ids = data.get('ids', [])
+        updates = data.get('updates', {})
+        tasks = Task.query.filter(Task.id.in_(ids)).all()
+        for task in tasks:
+            if 'progress' in updates:
+                task.progress = updates['progress']
+            if 'assignee_id' in updates:
+                task.assignee_id = updates['assignee_id']
+            if 'release_version' in updates:
+                task.release_version = updates['release_version']
+        db.session.commit()
+        return {'status': 'ok'}
+
+api.add_resource(TaskResource, '/task/<int:id>')
+api.add_resource(UpdateTask, '/task/update')
+api.add_resource(UpdateDates, '/task/update_dates')
+api.add_resource(BulkEdit, '/bulk_edit')

--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from sqlalchemy import text
 
 from models import db, Task, User, Project, Resource, Member, TaskDependency
+from api import api_bp
 
 app = Flask(__name__)
 app.secret_key = 'dev'
@@ -19,6 +20,41 @@ current_project_path = None
 
 login_manager = LoginManager(app)
 login_manager.login_view = 'login'
+app.register_blueprint(api_bp, url_prefix='/api')
+
+def compute_gantt(tasks):
+    import pandas as pd
+    import plotly.express as px
+
+    records = []
+    for t in tasks:
+        records.append({
+            'id': t.id,
+            'Task': t.name,
+            'Start': t.start_date,
+            'Finish': t.end_date,
+            'Progress': t.progress,
+            'resource_name': t.assignee.name if t.assignee else '',
+            'release_revision': t.release_version,
+        })
+    df = pd.DataFrame(records)
+    if df.empty:
+        return None
+    df['label'] = df['resource_name'] + ' (' + df['release_revision'].fillna('') + ')'
+    fig = px.timeline(
+        df,
+        x_start='Start',
+        x_end='Finish',
+        y='Task',
+        color='Progress',
+        text='label',
+        color_continuous_scale=['#dc3545', '#ffc107', '#28a745'],
+        range_color=[0, 100],
+    )
+    fig.update_traces(textposition='inside', insidetextanchor='middle')
+    fig.update_traces(customdata=df[['id']])
+    fig.update_yaxes(autorange='reversed')
+    return fig.to_html(full_html=False, include_plotlyjs=False)
 
 
 @app.route('/setup', methods=['GET', 'POST'])
@@ -535,7 +571,7 @@ def dashboard():
             remaining = sum(1 for t in tasks if t.progress < 100 and t.end_date >= cur_date)
             remaining_by_date.append({"date": cur_date.strftime("%Y-%m-%d"), "remaining": remaining})
             cur_date += timedelta(days=1)
-
+    gantt = compute_gantt(tasks) if tasks else None
     return render_template('index.html', **{
         "total_tasks": total_tasks,
         "completed_tasks": completed_tasks,
@@ -543,7 +579,8 @@ def dashboard():
         "progress_rate": progress_rate,
         "remaining_by_date": remaining_by_date,
         "releases": releases,
-        "selected_release": release
+        "selected_release": release,
+        "gantt": gantt
     })
 
 
@@ -556,31 +593,7 @@ def gantt_chart():
         query = query.filter(Task.release_version == release)
     tasks = query.all()
     releases = [r[0] for r in db.session.query(Task.release_version).distinct().all() if r[0]]
-    if tasks:
-        import pandas as pd
-        import plotly.express as px
-        df = pd.DataFrame([
-            {
-                "Task": t.name,
-                "Start": t.start_date,
-                "Finish": t.end_date,
-                "Progress": t.progress,
-            }
-            for t in tasks
-        ])
-        fig = px.timeline(
-            df,
-            x_start="Start",
-            x_end="Finish",
-            y="Task",
-            color="Progress",
-            color_continuous_scale=["#dc3545", "#ffc107", "#28a745"],
-            range_color=[0, 100],
-        )
-        fig.update_yaxes(autorange="reversed")
-        gantt = fig.to_html(full_html=False, include_plotlyjs=False)
-    else:
-        gantt = None
+    gantt = compute_gantt(tasks) if tasks else None
     return render_template(
         "gantt.html",
         gantt=gantt,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask_SQLAlchemy
 Flask_Login
 pandas
 plotly
+flask-restful


### PR DESCRIPTION
## Summary
- fix dashboard gantt generation and register API blueprint
- add compute_gantt helper
- create `api.py` with CRUD endpoints using Flask-RESTful
- update requirements for `flask-restful`

## Testing
- `python -m py_compile app.py api.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_688b7c45809c8321b003b492096f864e