### PR TITLE
Harden Flask secret key configuration

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,8 +15,12 @@ from models import db, Task, User, Project, Resource, Member, TaskDependency
 from api import api_bp
 from task_ordering import append_task_to_parent, move_task_within_siblings, sort_tasks_hierarchically
 
+def resolve_secret_key():
+    return os.environ.get('PMT_SECRET_KEY') or os.environ.get('SECRET_KEY') or 'dev'
+
+
 app = Flask(__name__)
-app.secret_key = 'dev'
+app.secret_key = resolve_secret_key()
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 # Keep track of currently opened project directory

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -107,6 +107,35 @@ class ProjectManagementToolTestCase(unittest.TestCase):
             self.assertIsNotNone(user)
             self.assertEqual(user.role, "Admin")
 
+    def test_app_uses_environment_secret_key_when_provided(self):
+        previous_pmt_secret = os.environ.get("PMT_SECRET_KEY")
+        previous_secret = os.environ.get("SECRET_KEY")
+        try:
+            os.environ["PMT_SECRET_KEY"] = "pmt-secret-for-test"
+            os.environ["SECRET_KEY"] = "generic-secret-for-test"
+            self.assertEqual(
+                app_module.resolve_secret_key(),
+                "pmt-secret-for-test",
+            )
+
+            os.environ.pop("PMT_SECRET_KEY", None)
+            self.assertEqual(
+                app_module.resolve_secret_key(),
+                "generic-secret-for-test",
+            )
+
+            os.environ.pop("SECRET_KEY", None)
+            self.assertEqual(app_module.resolve_secret_key(), "dev")
+        finally:
+            if previous_pmt_secret is None:
+                os.environ.pop("PMT_SECRET_KEY", None)
+            else:
+                os.environ["PMT_SECRET_KEY"] = previous_pmt_secret
+            if previous_secret is None:
+                os.environ.pop("SECRET_KEY", None)
+            else:
+                os.environ["SECRET_KEY"] = previous_secret
+
     def test_viewer_can_select_project_and_view_tasks(self):
         self.create_user("viewer", role="Viewer")
 


### PR DESCRIPTION
### Motivation

- Prevent using a hard-coded Flask secret key (`'dev'`) and allow deployment environments to provide a secure key via environment variables.
- Ensure behavior is deterministic and testable by defining explicit precedence for secret key sources.

### Description

- Added `resolve_secret_key()` in `app.py` which returns `PMT_SECRET_KEY` then `SECRET_KEY` and falls back to `'dev'` if neither is set, and wired it to `app.secret_key`.
- Replaced the fixed `app.secret_key = 'dev'` with `app.secret_key = resolve_secret_key()`.
- Added `test_app_uses_environment_secret_key_when_provided` to `tests/test_app.py` to validate precedence (`PMT_SECRET_KEY` → `SECRET_KEY` → `dev`) and to avoid regressions.

### Testing

- Ran `pytest` without `PYTHONPATH` which previously surfaced a collection error (`ModuleNotFoundError: No module named 'app'`) due to import path, so tests are executed with `PYTHONPATH=.`.
- Ran `PYTHONPATH=. pytest -q` and all tests passed: `17 passed` (complete test run succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1a12109988321a8e617928bfaa7e1)